### PR TITLE
Switching from GHCR to DockerHub

### DIFF
--- a/ww-cell-ranger-options.json
+++ b/ww-cell-ranger-options.json
@@ -1,0 +1,10 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": true,
+    "read_from_cache": true,
+    "default_runtime_attributes": {
+        "maxRetries": 1
+    },
+    "final_workflow_outputs_dir": "test-output/",
+    "use_relative_output_paths": true
+}

--- a/ww-cell-ranger.wdl
+++ b/ww-cell-ranger.wdl
@@ -102,7 +102,7 @@ task CellRangerCount {
   }
 
   runtime {
-    docker: "ghcr.io/getwilds/cellranger:6.0.2"
+    docker: "getwilds/cellranger:6.0.2"
     cpu: threads
   }
 


### PR DESCRIPTION
## Description
- Switching Docker images from GHCR to DockerHub because of call caching issues
- Also adding options json for usability

## Related Issue
- Fixes #2 